### PR TITLE
Fixes id incrementation in persistence api

### DIFF
--- a/assets/js/persistence.js
+++ b/assets/js/persistence.js
@@ -33,7 +33,7 @@ function saveEntityToLocalStorage(entity, key) {
 function getNextSequenceForEntity(key) {
   try {
     // Retrieves the stored data from localStorage
-    const storedData = JSON.parse(localStorage.getItem(key));
+    const storedData = loadEntityFromLocalStorage(key);
 
     let nextId = false;
 


### PR DESCRIPTION
getNextSequenceForEntity() method was using the wrong data to calculate the next sequence for id.